### PR TITLE
refactor: Making login and logout components dumber since they are in a

### DIFF
--- a/src/components/auth.js
+++ b/src/components/auth.js
@@ -9,7 +9,15 @@ class Auth extends Component {
         if (this.props.loginState.isLoggedIn) {
             return <Logout userState={this.props.userState} logout={this.props.logout}/>;
         } else {
-            return <Login login={this.props.login}/>;
+            return <Login login={(refs) => {
+              if (refs.email.refs) {
+                const user = {
+                    email: refs.email.refs.input.value,
+                    password: refs.password.refs.input.value
+                };
+                this.props.login(user);
+              }
+            }}/>;
         }
     }
 }

--- a/src/components/login.js
+++ b/src/components/login.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes} from 'react';
-import userActions from '../actions/userActions';
 import {
     Textfield,
     Button,
@@ -19,7 +18,7 @@ export class Login extends Component {
                                style={{color: 'Black', background: 'url(http://www.getmdl.io/assets/demos/dog.png) bottom right 15% no-repeat #46B6AC'}}>Email:fake@fakemail.com,
                         Hint: Pass: 123</CardTitle>
                     <CardText>
-                        <form onSubmit={() => this.handleSubmit()}>
+                        <form onSubmit={() => this.props.login(this.refs)}>
                             <Textfield
                                 onChange={() => {}}
                                 label="Email..."
@@ -39,18 +38,9 @@ export class Login extends Component {
             </div>
         )
     }
-
-    handleSubmit() {
-        const user = {
-            email: this.refs.email.refs.input.value,
-            password: this.refs.password.refs.input.value
-        };
-        this.props.login(user);
-    }
 }
 
 
 Login.propTypes = {
     login: PropTypes.func.isRequired
 };
-

--- a/src/components/logout.js
+++ b/src/components/logout.js
@@ -2,30 +2,26 @@ import React, { Component, PropTypes} from 'react';
 import { Button, Card, CardTitle, CardText } from 'react-mdl';
 import { Link }  from 'react-router';
 
-export class Logout extends Component {
-
-    render() {
-        return (
-            <div>
-                <Card shadow={0} style={{width: '320px', height: '320px', margin: 'auto'}}>
-                    <CardText>
-                        <Link to='/'>
-                            <Button accent style={{float: 'left'}}>
-                                No I rather stay
-                            </Button>
-                        </Link>
-                        <Button primary style={{float: 'right'}}
-                                onClick={this.props.logout}>
-                            Logout
-                        </Button>
-                    </CardText>
-                </Card>
-            </div>
-        );
-    }
-}
+export const Logout = ({
+  logout
+}) => (
+    <div>
+        <Card shadow={0} style={{width: '320px', height: '320px', margin: 'auto'}}>
+            <CardText>
+                <Link to='/'>
+                    <Button accent style={{float: 'left'}}>
+                        No I rather stay
+                    </Button>
+                </Link>
+                <Button primary style={{float: 'right'}}
+                        onClick={logout}>
+                    Logout
+                </Button>
+            </CardText>
+        </Card>
+    </div>
+);
 
 Logout.propTypes = {
-    logout: PropTypes.func.isRequired,
-    userState: PropTypes.object.isRequired
+    logout: PropTypes.func.isRequired
 };


### PR DESCRIPTION
smarter containter component auth. Login component does not know how to login, it just sends its form refs into the login handler function available
via props. Its not possible to make login a functional presentational component
since it contains refs. The logout component on the other hand should be as dumb
as possible hence a presentational component.
